### PR TITLE
Add several useful goals

### DIFF
--- a/Sources/LogicKit.swift
+++ b/Sources/LogicKit.swift
@@ -658,3 +658,11 @@ public func delayed(_ goal: @escaping Goal) -> Goal {
 public func solve(withInitialState state: State? = nil, _ program: Goal) -> Stream {
     return program(state ?? State())
 }
+
+
+/// A goal that always succeeds.
+public let success = (Value(true) === Value(true))
+
+
+/// A goal that always fails.
+public let failure = (Value(false) === Value(true))

--- a/Sources/LogicKit.swift
+++ b/Sources/LogicKit.swift
@@ -80,7 +80,7 @@ public class VariableFactory {
         self.state = self.state.withNextNewName()
         return self.variables[name]!
     }
-    
+
 }
 
 

--- a/Sources/LogicKit.swift
+++ b/Sources/LogicKit.swift
@@ -666,3 +666,55 @@ public let success = (Value(true) === Value(true))
 
 /// A goal that always fails.
 public let failure = (Value(false) === Value(true))
+
+
+/// Creates a goal that tests if a term is an instance of a `Value<T>`
+/// in the current substitution.
+public func isValue<T : Equatable>(_ term: Term, _ type: T.Type) -> Goal {
+    return in_environment { substitution in
+        if substitution [term] is Value<T> {
+          return success
+        } else {
+          return failure
+        }
+    }
+}
+
+
+/// Creates a goal that tests if a term is an instance of a `Variable`
+/// in the current substitution.
+public func isVariable(_ term: Term) -> Goal {
+    return in_environment { substitution in
+        if substitution [term] is Variable {
+          return success
+        } else {
+          return failure
+        }
+    }
+}
+
+
+/// Creates a goal that tests if a term is an instance of a `List`
+/// in the current substitution.
+public func isList(_ term: Term) -> Goal {
+    return in_environment { substitution in
+        if substitution [term] is List {
+          return success
+        } else {
+          return failure
+        }
+    }
+}
+
+
+/// Creates a goal that tests if a term is an instance of a `Map`
+/// in the current substitution.
+public func isMap(_ term: Term) -> Goal {
+    return in_environment { substitution in
+        if substitution [term] is Map {
+          return success
+        } else {
+          return failure
+        }
+    }
+}

--- a/Sources/LogicKit.swift
+++ b/Sources/LogicKit.swift
@@ -634,6 +634,18 @@ public func && (left: @escaping Goal, right: @escaping Goal) -> Goal {
 }
 
 
+/// Takes a goal constructor and returns a goal with substitution.
+///
+/// This function takes a *goal constructor* (i.e. a function), which accepts
+/// a substitution as parameter, and returns a new goal.
+public func in_environment (_ constructor: @escaping (Substitution) -> Goal) -> Goal {
+    return { state in
+        let reified = state.substitution.reified()
+        return constructor(reified)(state)
+    }
+}
+
+
 /// Takes a goal and returns a thunk that wraps it.
 public func delayed(_ goal: @escaping Goal) -> Goal {
     return { state in

--- a/Sources/LogicKit.swift
+++ b/Sources/LogicKit.swift
@@ -638,7 +638,7 @@ public func && (left: @escaping Goal, right: @escaping Goal) -> Goal {
 ///
 /// This function takes a *goal constructor* (i.e. a function), which accepts
 /// a substitution as parameter, and returns a new goal.
-public func in_environment (_ constructor: @escaping (Substitution) -> Goal) -> Goal {
+public func inEnvironment (_ constructor: @escaping (Substitution) -> Goal) -> Goal {
     return { state in
         let reified = state.substitution.reified()
         return constructor(reified)(state)


### PR DESCRIPTION
* `in_environment` can read the current substitutions;
* `success` is always successful;
* `failure` is never successful;
* `isValue` checks if a term is a `Value`;
* `isVariable` checks if a term is a `Variable`;
* `isList` checks if a term is a `List`;
* `isMap` checks if a term is a `Map`.

I have not added tests, but there are comments.